### PR TITLE
drop a metric we do not use

### DIFF
--- a/content/en/docs/01/labs/11.md
+++ b/content/en/docs/01/labs/11.md
@@ -11,7 +11,7 @@ sectionnumber: 1
 
 ### Task 2 (Advanced)
 
-* Use a metric relabel configuration to drop the metric `node_cpu_seconds_total`
+* Use a metric relabel configuration to drop the metric `net_conntrack_dialer_conn_failed_total`
 
 ## Solutions
 
@@ -102,7 +102,7 @@ killall -HUP prometheus
     - targets: ['localhost:9100']
   metric_relabel_configs:
     - source_labels: [ __name__ ]
-      regex: 'node_cpu_seconds_total'
+      regex: 'net_conntrack_dialer_conn_failed_total'
       action: drop
 ```
 {{% /details %}}


### PR DESCRIPTION
Let's drop a metric we do not use in a later lab :man_facepalming: 