### PR TITLE
Prevent nginx from adding the port in redirects

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,9 @@ RUN hugo --environment ${ACEND_HUGO_ENV} --minify
 
 FROM nginxinc/nginx-unprivileged:alpine
 
-EXPOSE 8080
+# prevent nginx from adding ports in redirects
+USER root
+RUN sed -i '/^http {/a \    port_in_redirect off;' /etc/nginx/nginx.conf
+USER 101
 
 COPY --from=builder /src/public /usr/share/nginx/html


### PR DESCRIPTION
Prevent nginx from adding the port in redirects which results in issues in proxied environments 