### PR TITLE
Remove http prefix

### DIFF
--- a/content/en/docs/01/_index.md
+++ b/content/en/docs/01/_index.md
@@ -118,7 +118,7 @@ To run Prometheus, you can simply execute the `prometheus` binary and define whe
     ```bash
     ./prometheus --config.file=prometheus.yml &
     ```
-1. You should now see Prometheus starting up with the log line `msg="Server is ready to receive web requests."`. To verify this, open your browser and navigate to <http://LOCALHOST:9090>. You should now see the Prometheus web UI.
+1. You should now see Prometheus starting up with the log line `msg="Server is ready to receive web requests."`. To verify this, open your browser and navigate to <LOCALHOST:9090>. You should now see the Prometheus web UI.
 
 {{% alert title="Note" color="primary" %}}
 If you use the provided Vagrant setup then ports 9090 (Prometheus), 9093 (Alertmanager), and 3000 (Grafana) are forwarded to the VM where Prometheus is running.

--- a/content/en/docs/01/labs/11.md
+++ b/content/en/docs/01/labs/11.md
@@ -121,7 +121,7 @@ Please note that `--web.enable-lifecycle` allows anyone with access to the Prome
 ### Verify in the web UI
 
 
-Check that the new target shows up in the web UI: <http://LOCALHOST:9090/targets>.
+Check that the new target shows up in the web UI: <LOCALHOST:9090/targets>.
 
 {{% /details %}}
 

--- a/content/en/docs/02/_index.md
+++ b/content/en/docs/02/_index.md
@@ -17,7 +17,7 @@ metric_name [
 ] value [ timestamp ]
 ```
 
-As an example, check the metrics of your Prometheus server (<http://LOCALHOST:9090/metrics>).
+As an example, check the metrics of your Prometheus server (<LOCALHOST:9090/metrics>).
 ```
 ...
 # HELP prometheus_tsdb_head_samples_appended_total Total number of appended samples.
@@ -43,7 +43,7 @@ There are 4 different metric types in Prometheus
 
 ## Explore Prometheus metrics
 
-Open your Prometheus [web UI](http://LOCALHOST:9090) and navigate to the **Graph** menu. You can use the `insert metric at cursor` drop-down list (next to the `Execute` button) to browse your metrics or start typing keywords in the expression field. Prometheus will try to find metrics that match your text.
+Open your Prometheus [web UI](LOCALHOST:9090) and navigate to the **Graph** menu. You can use the `insert metric at cursor` drop-down list (next to the `Execute` button) to browse your metrics or start typing keywords in the expression field. Prometheus will try to find metrics that match your text.
 
 Learn more about:
 

--- a/content/en/docs/02/labs/23.md
+++ b/content/en/docs/02/labs/23.md
@@ -63,7 +63,7 @@ killall -HUP prometheus
 ```
 
 Use your `recording_rule` definition in the expression browser:
-<http://LOCALHOST:9090/graph?g0.range_input=1h&g0.expr=%3Anode_memory_MemAvailable_bytes%3Asum>
+<LOCALHOST:9090/graph?g0.range_input=1h&g0.expr=%3Anode_memory_MemAvailable_bytes%3Asum>
 
 {{% /details %}}
 
@@ -88,5 +88,5 @@ Reload Prometheus
 killall -HUP prometheus
 ```
 
-Use your `recording_rule` definition in the expression browser: <http://LOCALHOST:9090/graph?g0.expr=instance%3Anode_cpu_utilisation%3Arate5m>
+Use your `recording_rule` definition in the expression browser: <LOCALHOST:9090/graph?g0.expr=instance%3Anode_cpu_utilisation%3Arate5m>
 {{% /details %}}

--- a/content/en/docs/03/_index.md
+++ b/content/en/docs/03/_index.md
@@ -95,7 +95,7 @@ To run Alertmanager you can simply execute the `alertmanager` binary and point i
     ./alertmanager --config.file=alertmanager.yml &
     ```
 
-1. You should now see Alertmanager starting up with the log line `msg=Listening address=:9093."`. To verify this open your browser and navigate to [http://LOCALHOST:9093](http://LOCALHOST:9093). You should now see the Alertmanager web UI.
+1. You should now see Alertmanager starting up with the log line `msg=Listening address=:9093."`. To verify this open your browser and navigate to [LOCALHOST:9093](LOCALHOST:9093). You should now see the Alertmanager web UI.
 
 Before moving on, let's make some warm-up [labs for monitoring your Alertmanager](labs/31).
 

--- a/content/en/docs/03/labs/33.md
+++ b/content/en/docs/03/labs/33.md
@@ -89,8 +89,8 @@ curl http://localhost:8080/metrics
 curl: (7) Failed connect to localhost:8080; Connection refused
 ```
 
-* In the Prometheus web UI there is an **Alerts** [menu item](http://LOCALHOST:9090/alerts) which shows you information about inactive and active alerts.
-* As soon as an alert is in state `FIRING` the alert is sent to Alertmanager. You should see the alert in its [web UI](http://LOCALHOST:9093).
+* In the Prometheus web UI there is an **Alerts** [menu item](LOCALHOST:9090/alerts) which shows you information about inactive and active alerts.
+* As soon as an alert is in state `FIRING` the alert is sent to Alertmanager. You should see the alert in its [web UI](LOCALHOST:9093).
 
 {{% /details %}}
 

--- a/content/en/docs/04/labs/41.md
+++ b/content/en/docs/04/labs/41.md
@@ -76,7 +76,7 @@ scrape_configs:
 
 {{% details title="Task 2" %}}
 
-[http://LOCALHOST:9090/graph?g0.range_input=1h&g0.expr=%7Binstance%3D%22https%3A%2F%2Fhttpstat.us%2F418%22%7D&g0.tab=1](http://LOCALHOST:9090/graph?g0.range_input=1h&g0.expr=%7Binstance%3D%22https%3A%2F%2Fhttpstat.us%2F418%22%7D&g0.tab=1)
+[LOCALHOST:9090/graph?g0.range_input=1h&g0.expr=%7Binstance%3D%22https%3A%2F%2Fhttpstat.us%2F418%22%7D&g0.tab=1](LOCALHOST:9090/graph?g0.range_input=1h&g0.expr=%7Binstance%3D%22https%3A%2F%2Fhttpstat.us%2F418%22%7D&g0.tab=1)
 
 **Warning:** In the list of metrics you will find one metric with the name `up`. In the case of a multi-target exporter such as the blackbox exporter this metric will always be up as long as Prometheus is able to successfully scrape the exporter even if the actual target (website, TCP service, etc.) is down. To monitor the state of the targets always use the `probe_success` metric.
 

--- a/content/en/docs/04/labs/42.md
+++ b/content/en/docs/04/labs/42.md
@@ -65,7 +65,7 @@ some_metric_total 42
 EOF
 ```
 
-Verify: [http://LOCALHOST:9090/graph?g0.range_input=1h&g0.expr=some_metric_total&g0.tab=1](http://LOCALHOST:9090/graph?g0.range_input=1h&g0.expr=some_metric_total&g0.tab=1)
+Verify: [LOCALHOST:9090/graph?g0.range_input=1h&g0.expr=some_metric_total&g0.tab=1](LOCALHOST:9090/graph?g0.range_input=1h&g0.expr=some_metric_total&g0.tab=1)
 
 If you see the labels `exported_instance` and `exported_job` in the Prometheus expression browser you did not set `honor_labels: true` in the Pushgateway scrape configuration.
 {{% /details %}}

--- a/content/en/docs/06/_index.md
+++ b/content/en/docs/06/_index.md
@@ -39,7 +39,7 @@ sudo systemctl start grafana-server
 sudo systemctl enable grafana-server
 ```
 
-Login to your Grafana instance <http://LOCALHOST:3000/> with:
+Login to your Grafana instance <LOCALHOST:3000/> with:
 
 | Username | Password |
 |---       |---       |

--- a/content/en/docs/06/labs/61.md
+++ b/content/en/docs/06/labs/61.md
@@ -37,7 +37,7 @@ Reload Prometheus
 killall -HUP prometheus
 ```
 
-Check if Prometheus can scrape the new metrics: <http://LOCALHOST:9090/targets>
+Check if Prometheus can scrape the new metrics: <LOCALHOST:9090/targets>
 {{% /details %}}
 
 {{% details title="Task 2" %}}


### PR DESCRIPTION
Running TLS on VM setup, therefore remove http:// prefix. URL will be provided as `https://prometheus-training.puzzle.ch/?h=https://xyz.xip.puzzle.ch`