### PR TITLE
fix alert routing

### DIFF
--- a/content/en/docs/03/labs/33.md
+++ b/content/en/docs/03/labs/33.md
@@ -33,7 +33,7 @@ Refer to the [official documentation](https://prometheus.io/docs/prometheus/late
 
 * Define an alerting rule which sends an alert when a target is down. Remember the `up` metric?
 * New alarms should be in `pending` state for 2 minutes before they transition to firing
-* Add a label `team` with the value `team-b`
+* Add a label `team` with the value `team-a`
 * Add an annotation `summary` with information about which instance and job is down
 
 {{% details title="Hints" mode-switcher="normalexpertmode" %}}
@@ -48,7 +48,7 @@ groups:
     expr: up == 0
     for: 2m
     labels:
-      team: team-b
+      team: team-a
     annotations:
       summary: Instance {{ $labels.instance }} of job {{ $labels.job }} is down
 ```
@@ -113,7 +113,7 @@ Receivers `receiver-a` and `receiver-b` should be notified in this case.
 
 Explanation:
 
-* The label `team: team-b` set on the alert rule matches both receivers
+* The label `team: team-a` set on the alert rule matches both receivers
 * `continue: true` is set to true, therefore both receivers will be notified
 
 ```yaml


### PR DESCRIPTION
label `team="team-a"` is required to route to both receivers