### PR TITLE
Update lab 6.2.2 - missing recording rule

### DIFF
--- a/content/en/docs/06/labs/62.md
+++ b/content/en/docs/06/labs/62.md
@@ -63,7 +63,13 @@ In this task you're going to create your first own dashboard `happy_little_dashb
   * Select the **thanos-querier** data source
 {{% /onlyWhen %}}
   * In general, metrics can be built using the [Grafana Query Builder](https://grafana.com/blog/2022/07/18/new-in-grafana-9-the-prometheus-query-builder-makes-writing-promql-queries-easier/) or using "plain" PromQL queries. You can easily switch between these two at the top right of the query window. Going forward, we will use plain PromQL queries.
-  * Add the rule `instance:node_cpu_utilisation:rate5m` in the **Metrics Browser** dropdown
+  * Add the expression `instance:node_cpu_utilisation:rate5m` in the **Metrics Browser** dropdown
+{{% alert title="Note" color="primary" %}}
+If there are no results, the Recording Rule from lab 2.3.2 is missing and needs to be created.
+{{% onlyWhen baloise %}}
+Alternatively you can use a predefined Recording Rule, e.g. `node:cpu_requests:ratio7d`.
+{{% /onlyWhen %}}
+{{% /alert %}}
 {{% onlyWhen baloise %}}
   * As the Recording Rule is evaluated by the local Prometheus as well as the global Thanos Ruler, we additionally need to explicitly select the label monitoringselector (`instance:node_cpu_utilisation:rate5m{monitoringselector="<team>-monitoring"}`).
 {{% /onlyWhen %}}


### PR DESCRIPTION
If the recording rule from lab 2.3.2 is missing, there is no result.